### PR TITLE
Add support for asynchronous test with arrow functions.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - [1.3 and earlier](#13-and-earlier)
 
 ### Upcoming...
+- Fix arrow functions (`(done) => { }`) support in asynchronous tests. ([#2](https://github.com/MithrilJS/ospec/pull/2) [@kesara](https://github.com/kesara))
 
 ### 4.0.1
 _2019-08-18_

--- a/ospec.js
+++ b/ospec.js
@@ -166,7 +166,7 @@ else window.o = m()
 				}
 				if (fn.length > 0) {
 					var body = fn.toString()
-					arg = (body.match(/^(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*=>/) || body.match(/\((?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)]/) || []).pop()
+					arg = (body.match(/\((.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)].*\s=>/) || body.match(/^(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*=>/) || body.match(/\((?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)]/) || []).pop()
 					if (body.indexOf(arg) === body.lastIndexOf(arg)) {
 						var e = new Error
 						e.stack = "'" + arg + "()' should be called at least once\n" + o.cleanStackTrace(task.err)

--- a/tests/test-ospec.js
+++ b/tests/test-ospec.js
@@ -305,6 +305,17 @@ o.spec("ospec", function() {
 					done()
 				})
 			})
+			o("hooks work as intended the third time (arrow function)", (done) => {
+				callAsync(function() {
+					var spy = o.spy()
+					spy(a)
+
+					o(a).equals(1)
+					o(b).equals(1)
+
+					done()
+				})
+			})
 		})
 	})
 

--- a/tests/test-ospec.js
+++ b/tests/test-ospec.js
@@ -304,22 +304,6 @@ o.spec("ospec", function() {
 					done()
 				})
 			})
-			/*eslint-disable no-eval*/
-			try {
-				eval("(()=>{})()")
-				o("hooks work as intended the third time (arrow function)", (done) => {
-					callAsync(function() {
-						var spy = o.spy()
-						spy(a)
-
-						o(a).equals(1)
-						o(b).equals(1)
-
-						done()
-					})
-				})
-			} catch (e) {/*ES5 env, or no eval, ignore*/}
-			/*eslint-enable no-eval*/
 		})
 	})
 
@@ -695,7 +679,7 @@ o.spec("ospec", function() {
 			})
 			oo.run(function(results) {
 				o(results.length).equals(2)
-				o(results[1].message).equals(`howdy\n\n${results[0].message}`)
+				o(results[1].message).equals('howdy\n\n'+results[0].message)
 				o(results[1].pass).equals(false)
 				done()
 			})
@@ -742,6 +726,21 @@ o.spec("the done parser", function() {
 				oo(
 					'Async test parser mistakenly identified 1st token after a parens to be `done` reference',
 					done => {
+						oo(threw).equals(false)
+						done()
+					}
+				)
+			*/}))
+			try {oo.run(function(){})} catch(e) {threw = true}
+			o(threw).equals(false)
+		})
+		o("has no false positives 2", function(){
+			var oo = o.new()
+			var threw = false
+			eval(getCommentContent(function(){/*
+				oo(
+					'Async test parser mistakenly identified 1st token after a parens to be `(done)` reference',
+					(done) => {
 						oo(threw).equals(false)
 						done()
 					}

--- a/tests/test-ospec.js
+++ b/tests/test-ospec.js
@@ -304,17 +304,22 @@ o.spec("ospec", function() {
 					done()
 				})
 			})
-			o("hooks work as intended the third time (arrow function)", (done) => {
-				callAsync(function() {
-					var spy = o.spy()
-					spy(a)
+			/*eslint-disable no-eval*/
+			try {
+				eval("(()=>{})()")
+				o("hooks work as intended the third time (arrow function)", (done) => {
+					callAsync(function() {
+						var spy = o.spy()
+						spy(a)
 
-					o(a).equals(1)
-					o(b).equals(1)
+						o(a).equals(1)
+						o(b).equals(1)
 
-					done()
+						done()
+					})
 				})
-			})
+			} catch (e) {/*ES5 env, or no eval, ignore*/}
+			/*eslint-enable no-eval*/
 		})
 	})
 


### PR DESCRIPTION
Asynchronous tests doesn't work with arrow functions

## Description
Add support for asynchronous test with arrow functions.

## Motivation and Context
Fix for #1.

## How Has This Been Tested?
Added test with arrow function to `ospec/tests/test-ospec.js`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`

