### PR TITLE
CLI: Add --module and --parallel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ Here's an example of mixing them all together:
 ospec '**/*.test.js' --ignore 'folder1/**' --require esm ./my-file.js
 ```
 
+#### For NodeJS v13+ only
+
+You can use ospec to test an ES6 module without depending on the `esm` NPM package. Use the `--module` option.
+
+If your CPU has more than one core, you can improve the test run time by using the `--parallel` option which creates one test worker per hardware thread.
+
 ### Run ospec directly from the command line:
 
 ospec comes with an executable named `ospec`. npm auto-installs local binaries to `./node_modules/.bin/`. You can run ospec by running `./node_modules/.bin/ospec` from your project root, but there are more convenient methods to do so that we will soon describe.

--- a/README.md
+++ b/README.md
@@ -366,6 +366,12 @@ You can also provide ignore patterns (note: always add `--ignore` AFTER match pa
 ospec --ignore 'folder1/**' 'folder2/**'
 ```
 
+If your CPU has more than one core, you can improve the test run time by using the `--parallel` option which, by default, creates one test worker per hardware thread provided by your CPU. You can also specify the number of workers to be spawned by passing a number to the parallel option (e.g. `--parallel 4`).
+
+```
+ospec --parallel
+```
+
 Finally, you may choose to load files or modules before any tests run (**note:** always add `--require` AFTER match patterns):
 
 ```
@@ -375,14 +381,12 @@ ospec --require esm
 Here's an example of mixing them all together:
 
 ```
-ospec '**/*.test.js' --ignore 'folder1/**' --require esm ./my-file.js
+ospec '**/*.test.js' --ignore 'folder1/**' --parallel 4 --require esm ./my-file.js
 ```
 
-#### For NodeJS v13+ only
+#### For NodeJS v13.2+ only
 
-You can use ospec to test an ES6 module without depending on the `esm` NPM package. Use the `--module` option.
-
-If your CPU has more than one core, you can improve the test run time by using the `--parallel` option which creates one test worker per hardware thread.
+You can use ospec to test ES6 modules without depending on the `esm` NPM package. Use the `--module` option.
 
 ### Run ospec directly from the command line:
 

--- a/bin/async-core.js
+++ b/bin/async-core.js
@@ -1,0 +1,115 @@
+"use strict"
+
+const o = require("../ospec")
+
+const glob = require("glob")
+const os = require("os")
+const path = require("path")
+const {Worker} = require("worker_threads")
+
+module.exports = async function asyncCore({globList, ignore, parallel, dependencies, cwd}) {
+	if (dependencies) await Promise.all(
+		dependencies.filter((dep) => dep != null).map(
+			(module) => import(require.resolve(module, {paths: [cwd]}))
+		)
+	)
+
+	var cores = parallel ? os.cpus().length : 1
+
+	const testQueue = []
+	const results = []
+	const threads = []
+	let globsPending = globList.length
+
+	function next(task, resolve, worker = null) {
+		if (testQueue.length > 0) resolve(task(testQueue.shift(), worker))
+		// poll to avoid a race condition when the test workers are
+		// being starved by a long-running glob with few matches
+		else if (globsPending > 0) setTimeout(() => next(task, resolve, worker), 10)
+		// nothing left in the queue, we're done.
+		else {
+			if (worker != null) worker.terminate()
+			resolve()
+		}
+	}
+
+	function localTask(path) {
+		// eslint-disable-next-line no-async-promise-executor
+		return new Promise(async (resolve) => {
+			try {
+				await import(path)
+				o.run((res) => {
+					results[path] = res
+					next(localTask, resolve)
+				})
+			} catch(e) {
+				results.push({pass: false, context: e.message, message: e.stack, error: e})
+				next(localTask, resolve)
+			}
+		})
+	}
+
+	function workerTask(path, worker) {
+		return new Promise((resolve) => {
+			worker.on("message", function onMessage(res) {
+				worker.off("message", onMessage)
+				results[path] = res
+				next(workerTask, resolve, worker)
+			})
+			worker.postMessage(path)
+		})
+	}
+
+	// with the parallel runner and multiple glob patters,
+	// the same file may end up being `imported()` several times
+	// in different threads. We thus keep a tally of the scheduled
+	// files to avoid the issue.
+	const scheduled = new Set()
+
+	function schedule(path) {
+		if (!scheduled.has(path)) {
+			scheduled.add(path)
+			if (cores-- > 0) {
+				if (cores > 0) {
+					threads.push(workerTask(path, new Worker(require.resolve("./worker"))))
+				} else {
+					// common path for non-parallel runs and for the last task
+					// in parallel mode, which runs in the same thread as the
+					// glob
+					threads.push(localTask(path))
+				}
+			} else testQueue.push(path)
+		}
+	}
+
+	// To minimize the thread communication overhead, messages are compressed
+	// to a success count and a failure list. Since the reporter expects a
+	// results list, we restore the "pass" items.
+	function unpack(results) {
+		// ensure that the reporting order is stable
+		return Object.keys(results).sort().flatMap((path) => {
+			const res = results[path]
+			return Array.isArray(res) ? res : unpackOneFile(JSON.parse(res))
+		})
+	}
+
+	const pass = {pass: true}
+	function unpackOneFile(results) {
+		const res = [...Array(results.pass + results.fail.length)]
+		res.forEach((_, i) => (
+			res[i] = i < results.fail.length ? results.fail[i] : pass
+		))
+		return res
+	}
+
+	globList.forEach((globPattern) => {
+		glob(globPattern, {ignore: ignore})
+			.on("match", (fileName) => { schedule(path.join(cwd, fileName)) })
+			.on("error", (e) => { console.error(e) })
+			.on("end", () => {if (--globsPending === 0) Promise.all(threads).then(() => {
+				const failures = o.report(unpack(results))
+				// eslint-disable-next-line no-process-exit
+				if (failures > 0) process.exit(1)
+			})})
+	});
+}

--- a/bin/async-core.js
+++ b/bin/async-core.js
@@ -67,9 +67,9 @@ module.exports = async function asyncCore({
 				next(localTask, fulfill)
 			})
 		} catch(e) {
-			results.push({
+			results[path] = [{
 				pass: false, context: e.message, message: e.stack, error: e
-			})
+			}]
 			next(localTask, fulfill)
 		}
 	}

--- a/bin/async-core.js
+++ b/bin/async-core.js
@@ -33,7 +33,7 @@ module.exports = async function asyncCore({
 
 	if (dependencies) await Promise.all(
 		dependencies.filter((dep) => dep != null).map(
-			(module) => load(require.resolve(module, {paths: [cwd]}))
+			(dep) => load(require.resolve(dep, {paths: [cwd]}))
 		)
 	)
 
@@ -76,6 +76,8 @@ module.exports = async function asyncCore({
 
 	function workerTask(path, fulfill, worker) {
 		worker.once("message", (res) => {
+			// do the minimal amount of work while
+			// the worker is idling.
 			results[path] = res
 			next(workerTask, fulfill, worker)
 		})

--- a/bin/compat.js
+++ b/bin/compat.js
@@ -13,14 +13,8 @@ function loadWithImport (x) {
 	return eval("import(x)")
 }
 
-function loadWithRequire (x) {
-	return new Promise((fulfill, reject) => {
-		try {
-			fulfill(require(x))
-		} catch(e) {
-			reject(e)
-		}
-	})
+async function loadWithRequire (x) {
+	return require(x)
 }
 
 function throwIt(e) {
@@ -31,7 +25,7 @@ const threadAPI = (() => {
 	try {
 		// Modern NodeJS
 		const {Worker, parentPort, workerData: wd} = require("worker_threads")
-		const useModule = wd != null && wd.indexOf("--module")
+		const useModule = wd != null && wd.indexOf("--module") !== -1
 		return {
 			spawn(name, workerData) {
 				const w = new Worker(name, {workerData})

--- a/bin/compat.js
+++ b/bin/compat.js
@@ -1,0 +1,84 @@
+// here lies code to even out API inconsistencies between
+// the various methods that can underlie the new test
+// runner:
+//
+// - `import()` vs `require()`
+// - `worker_threads` vs `child_process`
+
+function loadWithImport (x) {
+	return eval("import(x)")
+}
+
+function loadWithRequire (x) {
+	return new Promise((fulfill, reject) => {
+		try {
+			fulfill(require(x))
+		} catch(e) {
+			reject(e)
+		}
+	})
+}
+
+function onError(e) {
+	throw e
+}
+
+const threadAPI = (() => {
+	try {
+		// Modern NodeJS
+		const {Worker, parentPort, workerData: wd} = require("worker_threads")
+		const useModule = wd != null && wd.indexOf("--module")
+		return {
+			spawn(name, workerData) {
+				const w = new Worker(name, {workerData})
+				w.on("error", onError)
+				return w
+			},
+			// JSON.stringify()/.parse() is faster than the structured copy
+			// algorithm, especially for large objects. Also, postMessage
+			// seems not to like the results as they are handed by ospec.
+			// It hangs forever unless the objects are first copied
+			// manually.
+			sendMessage(worker, message) {
+				worker.postMessage(JSON.stringify(message))
+			},
+			decodeMessage(msg) {
+				return JSON.parse(msg)
+			},
+			terminate(worker) {
+				worker.terminate()
+			},
+			parent: parentPort,
+			useModule
+		}
+	} catch(_) {
+		// Fallback
+		const child_process = require("child_process")
+		const useModule = process.argv.indexOf("--module") !== -1
+		return {
+			spawn(name, args) {
+				const p = child_process.fork(name, args, {stdio: 'inherit'})
+				p.on("error", onError)
+				return p
+			},
+			sendMessage(_process, message) {
+				_process.send(message)
+			},
+			decodeMessage(msg) {
+				return msg
+			},
+			terminate(_process) {
+				_process.kill('SIGTERM')
+			},
+			parent: process,
+			useModule
+		}
+	}
+})()
+
+module.exports = Object.assign({
+		loadWithImport,
+		loadWithRequire,
+	},
+	threadAPI
+)

--- a/bin/compat.js
+++ b/bin/compat.js
@@ -25,7 +25,7 @@ const threadAPI = (() => {
 	try {
 		// Modern NodeJS
 		const {Worker, parentPort, workerData: wd} = require("worker_threads")
-		const useModule = wd != null && wd.indexOf("--module") !== -1
+		const useModule = wd != null && wd.includes("--module")
 		return {
 			spawn(name, workerData) {
 				const w = new Worker(name, {workerData})
@@ -52,7 +52,7 @@ const threadAPI = (() => {
 	} catch(_) {
 		// Fallback
 		const child_process = require("child_process")
-		const useModule = process.argv.indexOf("--module") !== -1
+		const useModule = process.argv.includes("--module")
 		return {
 			spawn(name, args) {
 				const p = child_process.fork(name, args, {stdio: 'inherit'})

--- a/bin/compat.js
+++ b/bin/compat.js
@@ -1,3 +1,5 @@
+"use strict"
+
 // here lies code to even out API inconsistencies between
 // the various methods that can underlie the new test
 // runner:
@@ -5,6 +7,8 @@
 // - `import()` vs `require()`
 // - `worker_threads` vs `child_process`
 
+// eval required for b/w compat (a bare `import()` causes the parser to
+// throw otherwise).
 function loadWithImport (x) {
 	return eval("import(x)")
 }

--- a/bin/compat.js
+++ b/bin/compat.js
@@ -19,7 +19,7 @@ function loadWithRequire (x) {
 	})
 }
 
-function onError(e) {
+function throwIt(e) {
 	throw e
 }
 
@@ -31,7 +31,7 @@ const threadAPI = (() => {
 		return {
 			spawn(name, workerData) {
 				const w = new Worker(name, {workerData})
-				w.on("error", onError)
+				w.on("error", throwIt)
 				return w
 			},
 			// JSON.stringify()/.parse() is faster than the structured copy
@@ -58,7 +58,7 @@ const threadAPI = (() => {
 		return {
 			spawn(name, args) {
 				const p = child_process.fork(name, args, {stdio: 'inherit'})
-				p.on("error", onError)
+				p.on("error", throwIt)
 				return p
 			},
 			sendMessage(_process, message) {

--- a/bin/compat.js
+++ b/bin/compat.js
@@ -28,17 +28,17 @@ const threadAPI = (() => {
 		const useModule = wd != null && wd.includes("--module")
 		return {
 			spawn(name, workerData) {
-				const w = new Worker(name, {workerData})
-				w.on("error", throwIt)
-				return w
+				const worker = new Worker(name, {workerData})
+				worker.on("error", throwIt)
+				return worker
 			},
 			// JSON.stringify()/.parse() is faster than the structured copy
 			// algorithm, especially for large objects. Also, postMessage
 			// seems not to like the results as they are handed by ospec.
 			// It hangs forever unless the objects are first copied
 			// manually.
-			sendMessage(worker, message) {
-				worker.postMessage(JSON.stringify(message))
+			sendMessage(target, message) {
+				target.postMessage(JSON.stringify(message))
 			},
 			decodeMessage(msg) {
 				return JSON.parse(msg)
@@ -55,18 +55,18 @@ const threadAPI = (() => {
 		const useModule = process.argv.includes("--module")
 		return {
 			spawn(name, args) {
-				const p = child_process.fork(name, args, {stdio: 'inherit'})
-				p.on("error", throwIt)
-				return p
+				const child = child_process.fork(name, args, {stdio: 'inherit'})
+				child.on("error", throwIt)
+				return child
 			},
-			sendMessage(_process, message) {
-				_process.send(message)
+			sendMessage(target, message) {
+				target.send(message)
 			},
 			decodeMessage(msg) {
 				return msg
 			},
-			terminate(_process) {
-				_process.kill('SIGTERM')
+			terminate(child) {
+				child.kill('SIGTERM')
 			},
 			parent: process,
 			useModule

--- a/bin/ospec
+++ b/bin/ospec
@@ -2,6 +2,8 @@
 "use strict"
 
 var o = require("../ospec")
+o("dummy spec to start the timer", () => {})
+
 var path = require("path")
 var glob = require("glob")
 
@@ -25,21 +27,29 @@ function parseArgs(argv) {
 var args = parseArgs(process.argv)
 var globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
 var ignore = ["**/node_modules/**"].concat(args.ignore || [])
+var parallel = args.parallel != null
+var isModule = args.module != null
+var dependencies = args.require
 var cwd = process.cwd()
 
-if (args.require) {
-	args.require.forEach(function(module) {
-		// eslint-disable-next-line global-require
-		if (module) require(require.resolve(module, {paths: [cwd]}))
-	})
-}
-
-var pending = globList.length
-globList.forEach(function(globPattern) {
-	glob(globPattern, {ignore: ignore})
-		.on("match", function(fileName) { require(path.join(cwd, fileName)) }) // eslint-disable-line global-require
-		.on("error", function(e) { console.error(e) })
-		.on("end", function() { if (--pending === 0) o.run()})
-});
-
 process.on("unhandledRejection", function(e) { console.error("Uncaught (in promise) " + e.stack) })
+
+if (isModule || parallel) {
+	// eslint-disable-next-line global-require
+	require('./async-core')({globList, ignore, parallel, dependencies, cwd})
+} else {
+	if (dependencies) {
+		dependencies.forEach(function(module) {
+			// eslint-disable-next-line global-require
+			if (module) require(require.resolve(module, {paths: [cwd]}))
+		})
+	}
+	var pending = globList.length
+	globList.forEach(function(globPattern) {
+		glob(globPattern, {ignore: ignore})
+			// eslint-disable-next-line global-require
+			.on("match", function(fileName) { require(path.join(cwd, fileName)) })
+			.on("error", function(e) { console.error(e) })
+			.on("end", function() { if (--pending === 0) o.run()})
+	});
+}

--- a/bin/ospec
+++ b/bin/ospec
@@ -27,16 +27,16 @@ function parseArgs(argv) {
 var args = parseArgs(process.argv)
 var globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
 var ignore = ["**/node_modules/**"].concat(args.ignore || [])
-var parallel = args.parallel != null
-var isModule = args.module != null
+var parallel = args.parallel
+var useModule = args.module != null
 var dependencies = args.require
 var cwd = process.cwd()
 
 process.on("unhandledRejection", function(e) { console.error("Uncaught (in promise) " + e.stack) })
 
-if (isModule || parallel) {
+if (useModule || parallel) {
 	// eslint-disable-next-line global-require
-	require('./async-core')({globList, ignore, parallel, dependencies, cwd})
+	require('./async-core')({globList, ignore, parallel, useModule, dependencies, cwd})
 } else {
 	if (dependencies) {
 		dependencies.forEach(function(module) {

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -1,0 +1,50 @@
+"use strict"
+
+const {parentPort} = require("worker_threads")
+const o = require("../ospec")
+
+function cloneErr({name, stack, message}) {
+	return {name, stack, message}
+}
+
+parentPort.on("message", async function(path) {
+	try {
+		await import(path)
+		o.run(function(results) {
+			// JSON.stringify()/.parse() is faster than the structured copy
+			// algorithm, especially for large objects. Also, postMessage
+			// seems not to like the results as they are handed by ospec.
+			// It hangs forever unless the objects are first copied
+			// manually.
+			// We also compress the results, since most tests are expected to
+			// pass on a typical run.
+			parentPort.postMessage(JSON.stringify(
+				results.reduce(
+					(acc, r) => {
+						if (r.pass) {
+							acc.pass++
+						} else {
+							const {pass, context, message, error, testError} = r
+							acc.fail.push({
+								pass, context, message,
+								error: cloneErr(error), testError: cloneErr(testError)
+							})
+						}
+						return acc
+					},
+					{pass:0, fail:[]}
+				)
+			))
+		})
+	} catch(e) {
+		parentPort.postMessage(JSON.stringify({
+			pass: 0,
+			fail:[{
+				pass: false,
+				context: e.message,
+				message: e.stack,
+				error: cloneErr(e)
+			}]
+		}))
+	}
+})

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -1,24 +1,25 @@
 "use strict"
 
-const {parentPort} = require("worker_threads")
 const o = require("../ospec")
+const {
+	parent, sendMessage, decodeMessage,
+	loadWithImport, loadWithRequire, useModule
+} = require("./compat")
 
 function cloneErr({name, stack, message}) {
 	return {name, stack, message}
 }
 
-parentPort.on("message", async function(path) {
+const load = useModule ? loadWithImport : loadWithRequire
+
+parent.on("message", async function(path) {
 	try {
-		await import(path)
+		await load(decodeMessage(path))
 		o.run(function(results) {
-			// JSON.stringify()/.parse() is faster than the structured copy
-			// algorithm, especially for large objects. Also, postMessage
-			// seems not to like the results as they are handed by ospec.
-			// It hangs forever unless the objects are first copied
-			// manually.
-			// We also compress the results, since most tests are expected to
+			// We compress the results, since most tests are expected to
 			// pass on a typical run.
-			parentPort.postMessage(JSON.stringify(
+			sendMessage(
+				parent,
 				results.reduce(
 					(acc, r) => {
 						if (r.pass) {
@@ -34,17 +35,20 @@ parentPort.on("message", async function(path) {
 					},
 					{pass:0, fail:[]}
 				)
-			))
+			)
 		})
 	} catch(e) {
-		parentPort.postMessage(JSON.stringify({
-			pass: 0,
-			fail:[{
-				pass: false,
-				context: e.message,
-				message: e.stack,
-				error: cloneErr(e)
-			}]
-		}))
+		sendMessage(
+			parent,
+			{
+				pass: 0,
+				fail: [{
+					pass: false,
+					context: e.message,
+					message: e.stack,
+					error: cloneErr(e)
+				}]
+			}
+		)
 	}
 })

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@
 - [1.3 and earlier](#13-and-earlier)
 
 ### Upcoming...
+
+#### Tentatively for v4.1.0
+
+- Add the `--module` and `--parallel` options to the runner, for recent NodeJS versions
 - Fix arrow functions (`(done) => { }`) support in asynchronous tests. ([#2](https://github.com/MithrilJS/ospec/pull/2) [@kesara](https://github.com/kesara))
 
 ### 4.0.1

--- a/changelog.md
+++ b/changelog.md
@@ -14,9 +14,10 @@
 
 ### Upcoming...
 
-#### Tentatively for v4.1.0
+***Tentatively for v4.1.0***
 
-- Add the `--module` and `--parallel` options to the runner, for recent NodeJS versions
+- Add the `--module` option to the runner for native module support in NodeJS 13.2+
+- Add the `--parallel` options to the runner
 - Fix arrow functions (`(done) => { }`) support in asynchronous tests. ([#2](https://github.com/MithrilJS/ospec/pull/2) [@kesara](https://github.com/kesara))
 
 ### 4.0.1

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "glob": "^7.1.3"
   },
   "scripts": {
-    "test": "node bin/ospec"
+    "test": "node bin/ospec && node bin/ospec --parallel && node bin/ospec --module"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,21 +4,24 @@
   "description": "Noiseless testing framework",
   "main": "ospec.js",
   "unpkg": "ospec.js",
-  "keywords": [ "testing" ],
+  "keywords": ["testing"],
   "author": "Leo Horie <leohorie@hotmail.com>",
   "license": "MIT",
-  "files": [ "ospec.js", "bin" ],
+  "files": ["ospec.js", "bin"],
   "bin": "./bin/ospec",
   "repository": "github:MithrilJS/ospec",
   "dependencies": {
     "glob": "^7.1.3"
   },
   "scripts": {
-    "test": "npm run test:normal && npm run test:require  && npm run test:parallel  && npm run test:module  && npm run test:module-parallel",
-    "test:normal": "node bin/ospec",
-    "test:require": "node bin/ospec --require ./var/extra.js",
+    "test": "npm run test:no-module && npm run test:module",
+    "test:legacy": "npm run test:legacy:normal && npm run test:legacy:require",
+    "test:no-module": "npm run test:legacy && npm run test:parallel",
+    "test:legacy:normal": "node bin/ospec",
+    "test:legacy:require": "node bin/ospec --require ./var/extra.js",
+    "test:module": "npm run test:module:serial && npm run test:module:parallel",
     "test:parallel": "node bin/ospec --parallel 2 --require ./var/extra.js",
-    "test:module": "node bin/ospec --module --require ./var/extra.js",
-    "test:module-parallel": "node bin/ospec --module --parallel --require ./var/extra.js"
+    "test:module:serial": "node bin/ospec --module --require ./var/extra.js",
+    "test:module:parallel": "node bin/ospec --module --parallel --require ./var/extra.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "glob": "^7.1.3"
   },
   "scripts": {
-    "test": "node bin/ospec && node bin/ospec --parallel && node bin/ospec --module"
+    "test": "npm run test:normal && npm run test:require  && npm run test:parallel  && npm run test:module  && npm run test:module-parallel",
+    "test:normal": "node bin/ospec",
+    "test:require": "node bin/ospec --require ./var/extra.js",
+    "test:parallel": "node bin/ospec --parallel 2 --require ./var/extra.js",
+    "test:module": "node bin/ospec --module --require ./var/extra.js",
+    "test:module-parallel": "node bin/ospec --module --parallel --require ./var/extra.js"
   }
 }

--- a/tests/test-ospec.js
+++ b/tests/test-ospec.js
@@ -107,18 +107,19 @@ o.spec("reporting", function() {
 	})
 	o("o.report() returns the number of failures", function () {
 		var log = console.log, error = console.error
+		var oo = o.new()
 		console.log = o.spy()
 		console.error = o.spy()
 
 		function makeError(msg) {try{throw msg ? new Error(msg) : new Error} catch(e){return e}}
 		try {
-			var errCount = o.report([{pass: true}, {pass: true}])
+			var errCount = oo.report([{pass: true}, {pass: true}])
 
 			o(errCount).equals(0)
 			o(console.log.callCount).equals(1)
 			o(console.error.callCount).equals(0)
 
-			errCount = o.report([
+			errCount = oo.report([
 				{pass: false, error: makeError("hey"), message: "hey"}
 			])
 
@@ -126,7 +127,7 @@ o.spec("reporting", function() {
 			o(console.log.callCount).equals(2)
 			o(console.error.callCount).equals(1)
 
-			errCount = o.report([
+			errCount = oo.report([
 				{pass: false, error: makeError("hey"), message: "hey"},
 				{pass: true},
 				{pass: false, error: makeError("ho"), message: "ho"}

--- a/var/extra.js
+++ b/var/extra.js
@@ -1,0 +1,3 @@
+"use strict"
+
+console.log("loaded extra")


### PR DESCRIPTION
This adds the possibility to run ospec with ES6 modules without relying on `esm`, and to run tests in parallel.

## How Has This Been Tested?

The test suite passes with both new flags (added to the test entry in `package.json`).

I've added this patch as a git dependency to a sample module and tested the runner in all three modes (normal, `--module` and `--parallel`) with `package.json#type` modified accordingly.

I've actually implented this in the [Mithril repo](https://github.com/pygy/mithril.js/tree/ospec-parallel-module-experiment). The mithril suite runs fine, in ~2/3 of the time it takes in serial mode (on my 2 core CPU).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the change log (if applicable).
