### PR TITLE
Native esm support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
         "node": true
 	},
     "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2017
+    },
     "rules": {
         "accessor-pairs": "error",
         "array-bracket-spacing": [

--- a/README.md
+++ b/README.md
@@ -366,17 +366,21 @@ You can also provide ignore patterns (note: always add `--ignore` AFTER match pa
 ospec --ignore 'folder1/**' 'folder2/**'
 ```
 
-Finally, you may choose to load files or modules before any tests run (**note:** always add `--require` AFTER match patterns):
+Finally, you may choose to load files or modules before any tests run (**note:** always add `--preload` AFTER match patterns):
 
 ```
-ospec --require esm
+ospec --preload esm
 ```
 
 Here's an example of mixing them all together:
 
 ```
-ospec '**/*.test.js' --ignore 'folder1/**' --require esm ./my-file.js
+ospec '**/*.test.js' --ignore 'folder1/**' --preload esm ./my-file.js
 ```
+
+### native mjs and module support
+
+For Node.js versions >= 13.2, `ospec` supports both ES6 modules and CommonJS packages out of the box. `--preload esm` is thus not needed in that case.
 
 ### Run ospec directly from the command line:
 

--- a/bin/ospec
+++ b/bin/ospec
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 "use strict"
 
-var o = require("../ospec")
-var path = require("path")
-var glob = require("glob")
+const o = require("../ospec")
+const path = require("path")
+const glob = require("glob")
 
 // eval is needed because`import()` is a syntax error in older
 // node.js versions (pre 13.2).
@@ -20,9 +20,9 @@ const load = supportsImport ? (x) => eval("import(x)") : async (x) => require(x)
 
 function parseArgs(argv) {
 	argv = ["--globs"].concat(argv.slice(2))
-	var args = {}
-	var name
-	argv.forEach(function(arg) {
+	const args = {}
+	let name
+	argv.forEach((arg) => {
 		if ((/^--/).test(arg)) {
 			name = arg.substr(2)
 			args[name] = args[name] || []
@@ -34,28 +34,28 @@ function parseArgs(argv) {
 }
 
 
-var args = parseArgs(process.argv)
-var globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
-var ignore = ["**/node_modules/**"].concat(args.ignore || [])
-var cwd = process.cwd()
+const args = parseArgs(process.argv)
+const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
+const ignore = ["**/node_modules/**"].concat(args.ignore || [])
+const cwd = process.cwd()
 
 if (args.require) {
-	args.require.forEach(function(module) {
+	args.require.forEach((module) => {
 		// eslint-disable-next-line global-require
 		if (module) require(require.resolve(module, {paths: [cwd]}))
 	})
 }
 
-var tasks = []
-globList.forEach(function(globPattern) {
+const tasks = []
+globList.forEach((globPattern) => {
 	glob(globPattern, {ignore: ignore})
-		.on("match", function(fileName) { tasks.push(load(path.join(cwd, fileName)).catch((e) => {
+		.on("match", (fileName) => { tasks.push(load(path.join(cwd, fileName)).catch((e) => {
 			o('error while loading ' + path.join(cwd, fileName), () => {
 				o(true).equals(false)(e.stack)
 			})
 		})) })
-		.on("error", function(e) { console.error(e) })
-		.on("end", function() { Promise.all(tasks).then(() => o.run())})
+		.on("error", (e) => { console.error(e) })
+		.on("end", () => { Promise.all(tasks).then(() => o.run())})
 });
 
-process.on("unhandledRejection", function(e) { console.error("Uncaught (in promise) " + e.stack) })
+process.on("unhandledRejection", (e) => { console.error("Uncaught (in promise) " + e.stack) })

--- a/bin/ospec
+++ b/bin/ospec
@@ -25,7 +25,10 @@ function parseArgs(argv) {
 		if ((/^--/).test(arg)) {
 			name = arg.substr(2)
 			if (name === "require") {
-				if (args.preload.length === 0) console.warn("The --require option has been renamed --preload")
+				if (args.require == null) console.warn(
+					"/!\\ The --require option has been deprecated, use --preload instead"
+				)
+				args.require = true
 				name = "preload"
 			}
 			args[name] = args[name] || []

--- a/bin/ospec
+++ b/bin/ospec
@@ -5,6 +5,18 @@ var o = require("../ospec")
 var path = require("path")
 var glob = require("glob")
 
+// eval is needed because`import()` is a syntax error in older
+// node.js versions (pre 13.2).
+
+const supportsImport = (()=>{ try {
+// eslint-disable-line no-eval
+ return !!eval("import('./non-existant-file').catch(()=>{})")
+} catch(_) {
+	return false
+}})()
+
+ // eslint-disable-line global-require no-eval
+const load = supportsImport ? (x) => eval("import(x)") : async (x) => require(x)
 
 function parseArgs(argv) {
 	argv = ["--globs"].concat(argv.slice(2))
@@ -34,12 +46,16 @@ if (args.require) {
 	})
 }
 
-var pending = globList.length
+var tasks = []
 globList.forEach(function(globPattern) {
 	glob(globPattern, {ignore: ignore})
-		.on("match", function(fileName) { require(path.join(cwd, fileName)) }) // eslint-disable-line global-require
+		.on("match", function(fileName) { tasks.push(load(path.join(cwd, fileName)).catch((e) => {
+			o('error while loading ' + path.join(cwd, fileName), () => {
+				o(true).equals(false)(e.stack)
+			})
+		})) })
 		.on("error", function(e) { console.error(e) })
-		.on("end", function() { if (--pending === 0) o.run()})
+		.on("end", function() { Promise.all(tasks).then(() => o.run())})
 });
 
 process.on("unhandledRejection", function(e) { console.error("Uncaught (in promise) " + e.stack) })

--- a/bin/ospec
+++ b/bin/ospec
@@ -7,24 +7,27 @@ const glob = require("glob")
 
 // eval is needed because`import()` is a syntax error in older
 // node.js versions (pre 13.2).
-
-const supportsImport = (()=>{ try {
-// eslint-disable-line no-eval
- return !!eval("import('./non-existant-file').catch(()=>{})")
+const supportsImport = (() => { try {
+	// eslint-disable-next-line no-eval
+	return Boolean(eval("import('./non-existant-file').catch(()=>{})"))
 } catch(_) {
 	return false
 }})()
 
- // eslint-disable-line global-require no-eval
+// eslint-disable-next-line global-require, no-eval, no-unused-vars
 const load = supportsImport ? (x) => eval("import(x)") : async (x) => require(x)
 
 function parseArgs(argv) {
 	argv = ["--globs"].concat(argv.slice(2))
-	const args = {}
+	const args = {preload: []}
 	let name
 	argv.forEach((arg) => {
 		if ((/^--/).test(arg)) {
 			name = arg.substr(2)
+			if (name === "require") {
+				if (args.preload.length === 0) console.warn("The --require option has been renamed --preload")
+				name = "preload"
+			}
 			args[name] = args[name] || []
 		} else {
 			args[name].push(arg)
@@ -39,23 +42,21 @@ const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.
 const ignore = ["**/node_modules/**"].concat(args.ignore || [])
 const cwd = process.cwd()
 
-if (args.require) {
-	args.require.forEach((module) => {
-		// eslint-disable-next-line global-require
-		if (module) require(require.resolve(module, {paths: [cwd]}))
-	})
-}
-
-const tasks = []
-globList.forEach((globPattern) => {
-	glob(globPattern, {ignore: ignore})
-		.on("match", (fileName) => { tasks.push(load(path.join(cwd, fileName)).catch((e) => {
-			o('error while loading ' + path.join(cwd, fileName), () => {
-				o(true).equals(false)(e.stack)
-			})
-		})) })
-		.on("error", (e) => { console.error(e) })
-		.on("end", () => { Promise.all(tasks).then(() => o.run())})
-});
+// Errors while preloading will be caught by the "unhandledRejection" handler.
+Promise.all(args.preload.map(((mod) => load(mod)))).then(
+	() => {
+		const tasks = []
+		globList.forEach((globPattern) => {
+			glob(globPattern, {ignore: ignore})
+				.on("match", (fileName) => { tasks.push(load(path.join(cwd, fileName)).catch((e) => {
+					o("error while loading " + path.join(cwd, fileName), () => {
+						o(true).equals(false)(e.stack)
+					})
+				})) })
+				.on("error", (e) => { console.error(e) })
+				.on("end", () => { Promise.all(tasks).then(() => o.run())})
+		})
+	}
+)
 
 process.on("unhandledRejection", (e) => { console.error("Uncaught (in promise) " + e.stack) })

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@
 
 ### Upcoming...
 - Fix another corner case with the done parser [#16](https://github.com/MithrilJS/ospec/pull/2) [@kfule](https://github.com/kfule)
+- Add native ES6 module support for recent Node.js versions.
+- deprecate `--require` and intrduce `--preload` since it can not load both CommonJS packages or ES6 modules (`--require` is still supported with a warning for easing the transition).
+all the things inclding bin/ospec.
 - Fix arrow functions (`(done) => { }`) support in asynchronous tests. ([#2](https://github.com/MithrilJS/ospec/pull/2) [@kesara](https://github.com/kesara))
 
 ### 4.0.1

--- a/package.json
+++ b/package.json
@@ -4,16 +4,24 @@
   "description": "Noiseless testing framework",
   "main": "ospec.js",
   "unpkg": "ospec.js",
-  "keywords": [ "testing" ],
+  "keywords": [
+    "testing"
+  ],
   "author": "Leo Horie <leohorie@hotmail.com>",
   "license": "MIT",
-  "files": [ "ospec.js", "bin" ],
+  "files": [
+    "ospec.js",
+    "bin"
+  ],
   "bin": "./bin/ospec",
   "repository": "github:MithrilJS/ospec",
   "dependencies": {
     "glob": "^7.1.3"
   },
   "scripts": {
-    "test": "node bin/ospec"
+    "test": "eslint . && bin/ospec"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "glob": "^7.1.3"
   },
   "scripts": {
-    "test": "eslint . bin/ospec && bin/ospec"
+    "test": "bin/ospec",
+    "lint": "eslint . bin/ospec"
   },
   "devDependencies": {
     "eslint": "^6.8.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glob": "^7.1.3"
   },
   "scripts": {
-    "test": "eslint . && bin/ospec"
+    "test": "eslint . bin/ospec && bin/ospec"
   },
   "devDependencies": {
     "eslint": "^6.8.0"

--- a/tests/test-ospec.js
+++ b/tests/test-ospec.js
@@ -679,7 +679,7 @@ o.spec("ospec", function() {
 			})
 			oo.run(function(results) {
 				o(results.length).equals(2)
-				o(results[1].message).equals('howdy\n\n'+results[0].message)
+				o(results[1].message).equals("howdy\n\n"+results[0].message)
 				o(results[1].pass).equals(false)
 				done()
 			})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add native ES modules support, rename `--require` to `--preload` to avoid confusion, add `eslint` to the `test` command.

## Motivation and Context
I'd like to have native module support. The parallel branch has issues I don't have the time to sort out right now.

## How Has This Been Tested?
The test suite passes and ESLint is happy. The tests still pass if `supportsImport` is manually set to `false`.

I didn't test this in earlier NodeJS versions, but IIRC Node 8+ supports async/await, and the `import`-related code is gated behind `eval()` calls to avoid syntax errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the change log (if applicable).
