### PR TITLE
markdown + minor content cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-ospec [![npm Version](https://img.shields.io/npm/v/ospec.svg)](https://www.npmjs.com/package/ospec) [![npm License](https://img.shields.io/npm/l/ospec.svg)](https://www.npmjs.com/package/ospec) [![npm Downloads](https://img.shields.io/npm/dm/ospec.svg)](https://www.npmjs.com/package/ospec) [![Donate at OpenCollective](https://img.shields.io/opencollective/all/mithriljs.svg?colorB=brightgreen)](https://opencollective.com/mithriljs)
-=====
+# ospec
 
-<p align="center">
-	<a href="https://travis-ci.org/MithrilJS/ospec">
-		<img src="https://img.shields.io/travis/MithrilJS/ospec/master.svg" alt="Build Status">
-	</a>
-	<a href="https://gitter.im/mithriljs/mithril.js">
-		<img src="https://img.shields.io/gitter/room/mithriljs/mithril.js.svg" alt="Gitter" />
-	</a>
-</p>
+[![npm License](https://img.shields.io/npm/l/ospec.svg)](https://www.npmjs.com/package/ospec) [![npm Version](https://img.shields.io/npm/v/ospec.svg)](https://www.npmjs.com/package/ospec) [![Build Status](https://img.shields.io/travis/MithrilJS/ospec/master.svg)](https://travis-ci.org/MithrilJS/ospec) [![npm Downloads](https://img.shields.io/npm/dm/ospec.svg)](https://www.npmjs.com/package/ospec)
+
+[![Donate at OpenCollective](https://img.shields.io/opencollective/all/mithriljs.svg?colorB=brightgreen)](https://opencollective.com/mithriljs) [![Gitter](https://img.shields.io/gitter/room/mithriljs/mithril.js.svg)](https://gitter.im/mithriljs/mithril.js)
+
+---
 
 [About](#about) | [Usage](#usage) | [CLI](#command-line-interface) | [API](#api) | [Goals](#goals)
 
@@ -21,13 +17,13 @@ Noiseless testing framework
 - test code reads like bullet points
 - assertion code follows [SVO](https://en.wikipedia.org/wiki/Subject–verb–object) structure in present tense for terseness and readability
 - supports:
-	- test grouping
-	- assertions
-	- spies
-	- `equals`, `notEquals`, `deepEquals` and `notDeepEquals` assertion types
-	- `before`/`after`/`beforeEach`/`afterEach` hooks
-	- test exclusivity (i.e. `.only`)
-	- async tests and hooks
+  - test grouping
+  - assertions
+  - spies
+  - `equals`, `notEquals`, `deepEquals` and `notDeepEquals` assertion types
+  - `before`/`after`/`beforeEach`/`afterEach` hooks
+  - test exclusivity (i.e. `.only`)
+  - async tests and hooks
 - explicitly regulates test-space configuration to encourage focus on testing, and to provide uniform test suites across projects
 
 ## Usage
@@ -40,10 +36,10 @@ Both tests and assertions are declared via the `o` function. Tests should have a
 var o = require("ospec")
 
 o("addition", function() {
-	o(1 + 1).equals(2)
+    o(1 + 1).equals(2)
 })
 o("subtraction", function() {
-	o(1 - 1).notEquals(2)
+    o(1 - 1).notEquals(2)
 })
 ```
 
@@ -51,11 +47,11 @@ Assertions may have descriptions:
 
 ```javascript
 o("addition", function() {
-	o(1 + 1).equals(2)("addition should work")
+    o(1 + 1).equals(2)("addition should work")
 
-	/* in ES6, the following syntax is also possible
-	o(1 + 1).equals(2) `addition should work`
-	*/
+    /* in ES6, the following syntax is also possible
+    o(1 + 1).equals(2) `addition should work`
+    */
 })
 /* for a failing test, an assertion with a description outputs this:
 
@@ -74,12 +70,12 @@ Tests may be organized into logical groups using `o.spec`
 
 ```javascript
 o.spec("math", function() {
-	o("addition", function() {
-		o(1 + 1).equals(2)
-	})
-	o("subtraction", function() {
-		o(1 - 1).notEquals(2)
-	})
+    o("addition", function() {
+        o(1 + 1).equals(2)
+    })
+    o("subtraction", function() {
+        o(1 - 1).notEquals(2)
+    })
 })
 ```
 
@@ -91,14 +87,14 @@ Groups can be nested to further organize test groups. Note that tests cannot be 
 
 ```javascript
 o.spec("math", function() {
-	o.spec("arithmetics", function() {
-		o("addition", function() {
-			o(1 + 1).equals(2)
-		})
-		o("subtraction", function() {
-			o(1 - 1).notEquals(2)
-		})
-	})
+    o.spec("arithmetics", function() {
+        o("addition", function() {
+            o(1 + 1).equals(2)
+        })
+        o("subtraction", function() {
+            o(1 - 1).notEquals(2)
+        })
+    })
 })
 ```
 
@@ -114,14 +110,14 @@ function call(cb, arg) {cb(arg)}
 var o = require("ospec")
 
 o.spec("call()", function() {
-	o("works", function() {
-		var spy = o.spy()
-		call(spy, 1)
+    o("works", function() {
+        var spy = o.spy()
+        call(spy, 1)
 
-		o(spy.callCount).equals(1)
-		o(spy.args[0]).equals(1)
-		o(spy.calls[0]).deepEquals([1])
-	})
+        o(spy.callCount).equals(1)
+        o(spy.args[0]).equals(1)
+        o(spy.calls[0]).deepEquals([1])
+    })
 })
 ```
 
@@ -131,19 +127,19 @@ A spy can also wrap other functions, like a decorator:
 //code to be tested
 var count = 0
 function inc() {
-	count++
+    count++
 }
 
 //test suite
 var o = require("ospec")
 
 o.spec("call()", function() {
-	o("works", function() {
-		var spy = o.spy(inc)
-		spy()
+    o("works", function() {
+        var spy = o.spy(inc)
+        spy()
 
-		o(count).equals(1)
-	})
+        o(count).equals(1)
+    })
 })
 
 ```
@@ -154,7 +150,7 @@ If a test body function declares a named argument, the test is assumed to be asy
 
 ```javascript
 o("setTimeout calls callback", function(done) {
-	setTimeout(done, 10)
+    setTimeout(done, 10)
 })
 ```
 
@@ -162,15 +158,15 @@ Alternativly you can return a promise or even use an async function in tests:
 
 ```javascript
 o("promise test", function() {
-	return new Promise(function(resolve) {
-		setTimeout(resolve, 10)
-	})
+    return new Promise(function(resolve) {
+        setTimeout(resolve, 10)
+    })
 })
 ```
 
 ```javascript
 o("promise test", async function() {
-	await someOtherAsyncFunction()
+    await someOtherAsyncFunction()
 })
 ```
 
@@ -181,21 +177,21 @@ its children by using the `o.specTimeout(delay)` function.
 
 ```javascript
 o.spec("a spec that must timeout quickly", function() {
-	// wait 20ms before bailing out of the tests of this suite and
-	// its descendants
-	o.specTimeout(20)
-	o("some test", function(done) {
-		setTimeout(done, 10) // this will pass
-	})
+    // wait 20ms before bailing out of the tests of this suite and
+    // its descendants
+    o.specTimeout(20)
+    o("some test", function(done) {
+        setTimeout(done, 10) // this will pass
+    })
 
-	o.spec("a child suite where the delay also applies", function () {
-		o("some test", function(done) {
-			setTimeout(done, 30) // this will time out.
-		})
-	})
+    o.spec("a child suite where the delay also applies", function () {
+        o("some test", function(done) {
+            setTimeout(done, 30) // this will time out.
+        })
+    })
 })
 o.spec("a spec that uses the default delay", function() {
-	// ...
+    // ...
 })
 ```
 
@@ -203,9 +199,9 @@ This can also be changed on a per-test basis using the `o.timeout(delay)` functi
 
 ```javascript
 o("setTimeout calls callback", function(done) {
-	o.timeout(500) //wait 500ms before bailing out of the test
+    o.timeout(500) //wait 500ms before bailing out of the test
 
-	setTimeout(done, 300)
+    setTimeout(done, 300)
 })
 ```
 
@@ -213,15 +209,15 @@ Note that the `o.timeout` function call must be the first statement in its test.
 
 ```javascript
 o("promise test", function() {
-	o.timeout(1000)
-	return someOtherAsyncFunctionThatTakes900ms()
+    o.timeout(1000)
+    return someOtherAsyncFunctionThatTakes900ms()
 })
 ```
 
 ```javascript
 o("promise test", async function() {
-	o.timeout(1000)
-	await someOtherAsyncFunctionThatTakes900ms()
+    o.timeout(1000)
+    await someOtherAsyncFunctionThatTakes900ms()
 })
 ```
 
@@ -233,21 +229,21 @@ These hooks can be declared when it's necessary to setup and clean up state for 
 
 ```javascript
 o.spec("math", function() {
-	var acc
-	o.beforeEach(function() {
-		acc = 0
-	})
+    var acc
+    o.beforeEach(function() {
+        acc = 0
+    })
 
-	o("addition", function() {
-		acc += 1
+    o("addition", function() {
+        acc += 1
 
-		o(acc).equals(1)
-	})
-	o("subtraction", function() {
-		acc -= 1
+        o(acc).equals(1)
+    })
+    o("subtraction", function() {
+        acc -= 1
 
-		o(acc).equals(-1)
-	})
+        o(acc).equals(-1)
+    })
 })
 ```
 
@@ -259,25 +255,25 @@ Like tests, hooks can also be asynchronous. Tests that are affected by asynchron
 
 ```javascript
 o.spec("math", function() {
-	var acc
-	o.beforeEach(function(done) {
-		setTimeout(function() {
-			acc = 0
-			done()
-		})
-	})
+    var acc
+    o.beforeEach(function(done) {
+        setTimeout(function() {
+            acc = 0
+            done()
+        })
+    })
 
-	//tests only run after async hooks complete
-	o("addition", function() {
-		acc += 1
+    //tests only run after async hooks complete
+    o("addition", function() {
+        acc += 1
 
-		o(acc).equals(1)
-	})
-	o("subtraction", function() {
-		acc -= 1
+        o(acc).equals(1)
+    })
+    o("subtraction", function() {
+        acc -= 1
 
-		o(acc).equals(-1)
-	})
+        o(acc).equals(-1)
+    })
 })
 ```
 
@@ -287,25 +283,25 @@ One or more tests can be temporarily made to run exclusively by calling `o.only(
 
 ```javascript
 o.spec("math", function() {
-	// will not run
-	o("addition", function() {
-		o(1 + 1).equals(2)
-	})
+    // will not run
+    o("addition", function() {
+        o(1 + 1).equals(2)
+    })
 
-	// this test will be run, regardless of how many groups there are
-	o.only("subtraction", function() {
-		o(1 - 1).notEquals(2)
-	})
+    // this test will be run, regardless of how many groups there are
+    o.only("subtraction", function() {
+        o(1 - 1).notEquals(2)
+    })
 
-	// will not run
-	o("multiplication", function() {
-		o(2 * 2).equals(4)
-	})
+    // will not run
+    o("multiplication", function() {
+        o(2 * 2).equals(4)
+    })
 
-	// this test will be run, regardless of how many groups there are
-	o.only("division", function() {
-		o(6 / 2).notEquals(2)
-	})
+    // this test will be run, regardless of how many groups there are
+    o.only("division", function() {
+        o(6 / 2).notEquals(2)
+    })
 })
 ```
 
@@ -314,7 +310,7 @@ o.spec("math", function() {
 ```javascript
 //define a test
 o("addition", function() {
-	o(1 + 1).equals(2)
+    o(1 + 1).equals(2)
 })
 
 //run the suite
@@ -328,7 +324,7 @@ The `o.new()` method can be used to create new instances of ospec, which can be 
 ```javascript
 var _o = o.new('optional name')
 _o("a test", function() {
-	_o(1).equals(1)
+    _o(1).equals(1)
 })
 _o.run()
 ```
@@ -336,16 +332,18 @@ _o.run()
 ## Command Line Interface
 
 Create a script in your package.json:
+
+```javascript
+    "scripts": {
+        "test": "ospec",
+        ...
+    }
 ```
-	"scripts": {
-		"test": "ospec",
-		...
-	}
-```
+
 ...and run it from the command line:
 
-```
-$ npm test
+```shell
+npm test
 ```
 
 **NOTE:** `o.run()` is automatically called by the cli - no need to call it in your test code.
@@ -356,25 +354,25 @@ Running ospec without arguments is equivalent to running `ospec '**/tests/**/*.j
 
 If you wish to change this behavior, just provide one or more glob match patterns:
 
-```
+```shell
 ospec '**/spec/**/*.js' '**/*.spec.js'
 ```
 
 You can also provide ignore patterns (note: always add `--ignore` AFTER match patterns):
 
-```
+```shell
 ospec --ignore 'folder1/**' 'folder2/**'
 ```
 
 Finally, you may choose to load files or modules before any tests run (**note:** always add `--preload` AFTER match patterns):
 
-```
+```shell
 ospec --preload esm
 ```
 
 Here's an example of mixing them all together:
 
-```
+```shell
 ospec '**/*.test.js' --ignore 'folder1/**' --preload esm ./my-file.js
 ```
 
@@ -382,7 +380,7 @@ ospec '**/*.test.js' --ignore 'folder1/**' --preload esm ./my-file.js
 
 For Node.js versions >= 13.2, `ospec` supports both ES6 modules and CommonJS packages out of the box. `--preload esm` is thus not needed in that case.
 
-### Run ospec directly from the command line:
+### Run ospec directly from the command line
 
 ospec comes with an executable named `ospec`. npm auto-installs local binaries to `./node_modules/.bin/`. You can run ospec by running `./node_modules/.bin/ospec` from your project root, but there are more convenient methods to do so that we will soon describe.
 
@@ -400,13 +398,13 @@ If you're using a recent version of npm (v5+), you can use run `npx ospec` from 
 
 Otherwise, to work around this limitation, you can use [`npm-run`](https://www.npmjs.com/package/npm-run) which enables one to run the binaries of locally installed packages.
 
-```
+```shell
 npm install npm-run -g
 ```
 
 Then, from a project that has ospec installed as a (dev) dependency:
 
-```
+```shell
 npm-run ospec
 ```
 
@@ -414,7 +412,7 @@ npm-run ospec
 
 If you understand how your system's PATH works (e.g. for [OSX](https://coolestguidesontheplanet.com/add-shell-path-osx/)), then you can add the following to your PATH...
 
-```
+```shell
 export PATH=./node_modules/.bin:$PATH
 ```
 
@@ -446,7 +444,7 @@ Starts an assertion. There are six types of assertion: `equals`, `notEquals`, `d
 
 Assertions have this form:
 
-```
+```shell
 o(actualValue).equals(expectedValue)
 ```
 
@@ -454,13 +452,13 @@ As a matter of convention, the actual value should be the first argument and the
 
 Assertions can also accept an optional description curried parameter:
 
-```
+```javascript
 o(actualValue).equals(expectedValue)("this is a description for this assertion")
 ```
 
 Assertion descriptions can be simplified using ES6 tagged template string syntax:
 
-```
+```javascript
 o(actualValue).equals(expectedValue) `this is a description for this assertion`
 ```
 
@@ -544,7 +542,7 @@ Returns a function that records the number of times it gets called, and its argu
 
 The number of times the function has been called
 
-#### Array<any> o.spy().args
+#### Array&lt;any> o.spy().args
 
 The arguments that were passed to the function in the last time it was called
 
@@ -562,7 +560,6 @@ If running in Node.js, ospec will call `process.exit` after reporting
 results by default. If you specify a reporter, ospec will not do this
 and allow your reporter to respond to results in its own way.
 
-
 ---
 
 ### Number o.report(results)
@@ -578,7 +575,7 @@ Returns a new instance of ospec. Useful if you want to run more than one test su
 ```javascript
 var $o = o.new()
 $o("a test", function() {
-	$o(1).equals(1)
+    $o(1).equals(1)
 })
 $o.run()
 ```
@@ -596,11 +593,11 @@ can use custom reporters in `o.run()` to process these results.
 
 ```javascript
 o.run(function(results) {
-	// results is an array
+    // results is an array
 
-	results.forEach(function(result) {
-		// ...
-	})
+    results.forEach(function(result) {
+        // ...
+    })
 })
 ```
 
@@ -634,7 +631,7 @@ As an example, the following test's result message will be `"false\nshould equal
 
 ```javascript
 o.spec("message", function() {
-	o(false).equals(true)
+    o(false).equals(true)
 })
 ```
 
@@ -642,7 +639,7 @@ If you specify an assertion description, that description will appear two lines 
 
 ```javascript
 o.spec("message", function() {
-	o(false).equals(true)("Candyland") // result.message === "Candyland\n\nfalse\nshould equal\ntrue"
+    o(false).equals(true)("Candyland") // result.message === "Candyland\n\nfalse\nshould equal\ntrue"
 })
 ```
 
@@ -655,9 +652,9 @@ In the below example, `result.context` would be `testing > rocks`.
 
 ```javascript
 o.spec("testing", function() {
-	o.spec("rocks", function() {
-		o(false).equals(true)
-	})
+    o.spec("rocks", function() {
+        o(false).equals(true)
+    })
 })
 ```
 
@@ -665,13 +662,13 @@ o.spec("testing", function() {
 
 ## Run time model
 
-### Definitions: 
+### Definitions
 
 - A **test** is the function passed to `o("description", function test() {})`.
 - A **hook** is a function passed to `o.before()`, `o.after()`. `o.beforeEach()` and `o.afterEach()`
 - A **task** designates either a test or a hook.
-- A given test and its associated `beforeEach` and `afterEach` hooks form a **streak**. The `beforeEach` hooks run outermost first, the `afterEach` run outermost last. The hooks are optional, and are tied at test-definition time in the `o.spec()` calls that enclose the test.
-- A **spec** is a collection of streaks, specs, one `before` *hook* and one `after` *hook*. Each component is optional. Specs are defined with the `o.spec("spec name", function specDef() {})` calls.
+- A **streak** is a given test and its associated `beforeEach` and `afterEach` hooks. The `beforeEach` hooks run outermost first, the `afterEach` run outermost last. The hooks are optional, and are tied at test-definition time in the `o.spec()` calls that enclose the test.
+- A **spec** is a collection of streaks, specs, one `before` hook and one `after` hook. Each component is optional. Specs are defined with the `o.spec("spec name", function specDef() {})` calls.
 
 ### The phases of an ospec run
 
@@ -699,7 +696,7 @@ Once all tests have run or timed out, the results are presented.
 
 While some testing libraries consider error thrown as assertions failure, `ospec` treats them as super-failures. Throwing will cause the current spec to be aborted, avoiding what can otherwise end up as pages of errors. What this means depends on when the error is thrown. Specifically:
 
-- A syntax error in a file causes the file to be ignored by the runner. 
+- A syntax error in a file causes the file to be ignored by the runner.
 - At test-definition time:
   - An error thrown at the root of a file will cause subsequent tests and specs to be ignored
   - An error thrown in a spec definition will cause the spec to be ignored.
@@ -707,7 +704,7 @@ While some testing libraries consider error thrown as assertions failure, `ospec
   - An error thrown in the `before` hook will cause the streaks and nested specs to be ignored. The `after` hook will run.
   - An error thrown in a task...
     - ...prevents further streaks and nested specs in the current spec from running. The `after` *hook* of the spec will run.
-    - ...if thrown in a `beforeEach` hook of a streak, causes the streak to be hollowed out. Hooks defined in nested scopes and the actual test will not run. The `afterEach` hook corresponding to the one that crashed will run though as will those defined in outer scopes.
+    - ...if thrown in a `beforeEach` hook of a streak, causes the streak to be hollowed out. Hooks defined in nested scopes and the actual test will not run. However, the `afterEach` hook corresponding to the one that crashed will run, as will those defined in outer scopes.
   
 For every error thrown, a "bail out" failure is reported.
 
@@ -717,9 +714,9 @@ For every error thrown, a "bail out" failure is reported.
 
 - Do the most common things that the mocha/chai/sinon triad does without having to install 3 different libraries and several dozen dependencies
 - Disallow configuration in test-space:
-	- Disallow ability to pick between API styles (BDD/TDD/Qunit, assert/should/expect, etc)
-	- Disallow ability to add custom assertion types
-	- Provide a default simple reporter
+  - Disallow ability to pick between API styles (BDD/TDD/Qunit, assert/should/expect, etc)
+  - Disallow ability to add custom assertion types
+  - Provide a default simple reporter
 - Make assertion code terse, readable and self-descriptive
 - Have as few assertion types as possible for a workable usage pattern
 

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ o.spec("testing", function() {
 - A **test** is the function passed to `o("description", function test() {})`.
 - A **hook** is a function passed to `o.before()`, `o.after()`. `o.beforeEach()` and `o.afterEach()`
 - A **task** designates either a test or a hook.
-- A **streak** is a given test and its associated `beforeEach` and `afterEach` hooks. The `beforeEach` hooks run outermost first, the `afterEach` run outermost last. The hooks are optional, and are tied at test-definition time in the `o.spec()` calls that enclose the test.
+- A given test and its associated `beforeEach` and `afterEach` hooks form a **streak**. The `beforeEach` hooks run outermost first, the `afterEach` run outermost last. The hooks are optional, and are tied at test-definition time in the `o.spec()` calls that enclose the test.
 - A **spec** is a collection of streaks, specs, one `before` hook and one `after` hook. Each component is optional. Specs are defined with the `o.spec("spec name", function specDef() {})` calls.
 
 ### The phases of an ospec run


### PR DESCRIPTION
## Description
These are clerical edits to readme.md, and address warnings emitted by markdownlint absent a lint config and using its defaults 
[devnotes-cleanup-readme-markdown.txt](https://github.com/MithrilJS/ospec/files/4965559/devnotes-cleanup-readme-markdown.txt)
(https://github.com/DavidAnson/vscode-markdownlint). Pls see detailed list of changes in attached devnotes-...txt file

## Motivation and Context
Opening readme.md in a linting markdown-editor produces a lot of visual noise (based on lint defaults); these edits address them.

## How Has This Been Tested?
running markdownlint-cli now produces warnings only re line-length

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [?] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the change log (if applicable).

[devnotes-cleanup-readme-markdown.txt](https://github.com/MithrilJS/ospec/files/4965660/devnotes-cleanup-readme-markdown.txt)
