### PR TITLE
Use conditional exports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@ Change log
 
 ### Upcoming...
 
-nothing yet
+Conditional exports for node with commonjs, node with es modules and browser.
 
 ### 4.1.1
 _2020-04-07_

--- a/export/default.js
+++ b/export/default.js
@@ -1,0 +1,3 @@
+import initOspec from "../ospec"
+
+export default o = initOspec(null)

--- a/export/nodeImport.js
+++ b/export/nodeImport.js
@@ -1,0 +1,4 @@
+import inspect from "util"
+import initOspec from "../ospec.js"
+
+export default o = initOspec(inspect)

--- a/export/nodeRequire.js
+++ b/export/nodeRequire.js
@@ -1,0 +1,4 @@
+const {inspect} = require("util")
+const initOspec = require("../ospec.js")
+
+module.exports = initOspec(inspect)

--- a/ospec.js
+++ b/ospec.js
@@ -25,14 +25,17 @@ In each of these tasks:
 */
 
 
-;(function(m) {
-if (typeof module !== "undefined") module["exports"] = m()
-else window.o = m()
-})(function init(name) {
+;(function (m) {
+	if (typeof module !== "undefined") {
+		module["exports"] = function (inspect) {return m(inspect) }
+	} else {
+		window.o = m(null)
+	}
+})(function init(inspect, name) {
 	// # Setup
 	// const
 	var hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
-	var hasSuiteName = arguments.length !== 0
+	var hasSuiteName = name !== undefined
 	var only = []
 	var ospecFileName = getStackName(ensureStackTrace(new Error), /[\/\\](.*?):\d+:\d+/)
 	var rootSpec = new Spec()
@@ -160,7 +163,7 @@ else window.o = m()
 		globalContext.specTimeout = t
 	}
 
-	o.new = init
+	o.new = function (name) { return init(inspect, name) }
 
 	o.spec = function(subject, predicate) {
 		if (isRunning()) throw new Error("`o.spec()` can't only be called at test definition time, not run time")

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "files": [
     "ospec.js",
-    "bin"
+    "bin",
+    "export"
   ],
   "bin": "./bin/ospec",
   "repository": "github:MithrilJS/ospec",
@@ -28,5 +29,13 @@
     "compose-regexp": "0.4.0",
     "eslint": "^6.8.0",
     "ospec": "4.1.1"
+  },
+  "module": "./export/default.js",
+  "exports": {
+    "node": {
+      "import": "./export/nodeImport.js",
+      "require": "./export/nodeRequire.js"
+    },
+    "default": "./export/default.js"
   }
 }

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -15,7 +15,7 @@ if (typeof require !== "undefined") {
 		&& process.argv[1].match(/ospec[\/\\]node_modules[\/\\]\.bin[\/\\]ospec$/)
 	)
 	/* eslint-disable global-require */
-	o = lib = require("../ospec")
+	o = lib = require("../export/nodeRequire.js")
 	if (loadFromDeps) o = require("ospec")
 	/* eslint-enable global-require */
 } else {


### PR DESCRIPTION
## Description
This commit changes how exports are defined to handle different
usage scenarios. Now build systems can detect what is required and node will
pick appropriate version.

## Motivation and Context
There are three different scenarios which require different imports:
node with commonjs, node with es modules and browser (assumed to have
es modules or be transpiled). Previously ospec would break if executed
in a module context, build systems are also not able to fix that
because require is used dynamically.
issue #25 

## How Has This Been Tested?
I ran test-api with node 12. I was not able to run test-cli before or after the changes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the change log (if applicable).
