### PR TITLE
Use dynamic import for node util

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@ Change log
 
 ### Upcoming...
 
-nothing yet
+- Support running in ESM mode of nodejs. 
 
 ### 4.1.1
 _2020-04-07_

--- a/ospec.js
+++ b/ospec.js
@@ -37,6 +37,14 @@ else window.o = m()
 	var ospecFileName = getStackName(ensureStackTrace(new Error), /[\/\\](.*?):\d+:\d+/)
 	var rootSpec = new Spec()
 	var subjects = []
+	var inspect
+	var inspectP
+
+	if (hasProcess) {
+		inspectP = import("util").then(function (util) {
+			inspect = util.inspect
+		})
+	}
 
 	// stack-managed globals
 	var globalBail
@@ -272,7 +280,7 @@ else window.o = m()
 		// always async for consistent external behavior
 		// otherwise, an async test would release Zalgo
 		// https://blog.izs.me/2013/08/designing-apis-for-asynchrony
-		nextTickish(function () {
+		Promise.resolve(inspectP).then(function () {
 			runSpec(hasSuiteName ? parent : rootSpec, [], [], finalize, 200 /*default timeout delay*/)
 		})
 
@@ -588,7 +596,7 @@ else window.o = m()
 	}
 
 	function serialize(value) {
-		if (hasProcess) return require("util").inspect(value) // eslint-disable-line global-require
+		if (inspect) return inspect(value) // eslint-disable-line global-require
 		if (value === null || (typeof value === "object" && !(value instanceof Array)) || typeof value === "number") return String(value)
 		else if (typeof value === "function") return value.name || "<anonymous function>"
 		try {return JSON.stringify(value)} catch (e) {return String(value)}

--- a/tests/test-import.js
+++ b/tests/test-import.js
@@ -1,0 +1,14 @@
+"use strict"
+const o = require("../ospec")
+
+class Foo {}
+
+class NonFoo {}
+
+o.spec("test", () => {
+	o("it works", () => {
+		o(Foo).equals(NonFoo)
+	})
+})
+
+o.run()


### PR DESCRIPTION
## Description
This commit replaces `require()` with `import()`.

## Motivation and Context
With this change ospec is able to run in both es6 and commonjs modes of node. `require()` is not allowed in es6 mode which is a problem for apps which build targets esm.

## How Has This Been Tested?
`npm test`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the change log (if applicable).
