### PR TITLE
Fix postinstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,13 @@ jobs:
           - windows-latest
         node_version:
           - 14
-          - 16
-          - 18
         architecture:
           - x64
+        include:
+          - os: ubuntu-latest
+            node_version: 16
+          - os: ubuntu-latest
+            node_version: 18
 
     steps:
     # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,36 +74,7 @@ jobs:
           - 18
         architecture:
           - x64
-        shell :
-          - bash
-        include:
-          - os: windows-latest
-            shell: cmd
-            node_version: 14
-          - os: windows-latest
-            shell: powershell
-            node_version: 14
-          - os: windows-latest
-            shell: pwsh
-            node_version: 14
-          - os: windows-latest
-            shell: cmd
-            node_version: 16
-          - os: windows-latest
-            shell: powershell
-            node_version: 16
-          - os: windows-latest
-            shell: pwsh
-            node_version: 16
-          - os: windows-latest
-            shell: cmd
-            node_version: 18
-          - os: windows-latest
-            shell: powershell
-            node_version: 18
-          - os: windows-latest
-            shell: pwsh
-            node_version: 18
+
     steps:
     # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  tests:
+  test-cli:
     runs-on: ${{ matrix.os }}
-    name: Node.js ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }} with ${{ matrix.shell }}
+    name: CLI Tests, Node.js ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }} with ${{ matrix.shell }}
     strategy:
       matrix:
         os:
@@ -58,4 +58,60 @@ jobs:
         node-version: ${{ matrix.node_version }}
     - run: npm ci
     - run: corepack enable
-    - run: npm run test
+    - run: npm run test-cli
+  test-api:
+    runs-on: ${{ matrix.os }}
+    name: API tests, Node.js ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }} with ${{ matrix.shell }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node_version:
+          - 14
+          - 16
+          - 18
+        architecture:
+          - x64
+        shell :
+          - bash
+        include:
+          - os: windows-latest
+            shell: cmd
+            node_version: 14
+          - os: windows-latest
+            shell: powershell
+            node_version: 14
+          - os: windows-latest
+            shell: pwsh
+            node_version: 14
+          - os: windows-latest
+            shell: cmd
+            node_version: 16
+          - os: windows-latest
+            shell: powershell
+            node_version: 16
+          - os: windows-latest
+            shell: pwsh
+            node_version: 16
+          - os: windows-latest
+            shell: cmd
+            node_version: 18
+          - os: windows-latest
+            shell: powershell
+            node_version: 18
+          - os: windows-latest
+            shell: pwsh
+            node_version: 18
+    steps:
+    # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node_version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node_version }}
+    - run: npm ci
+    - run: corepack enable
+    - run: npm run test-api

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,13 @@
 Change log
 ======
 
-### 4.1.2
+### 4.1.3
+
+#### Bug fixes
+_2022-05-18_
+- Fix post-install crash introduced in v4.1.2
+
+### 4.1.2 
 
 #### Bug fixes
 _2022-05-17_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ospec",
-  "version": "4.1.2-postinstall-experiments",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ospec",
-      "version": "4.1.2-postinstall-experiments",
+      "version": "4.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,7 @@
         "cmd-shim": "4.0.2",
         "compose-regexp": "0.6.22",
         "eslint": "^6.8.0",
-        "ospec-stable": "npm:ospec@4.1.1-and-then-some"
+        "ospec-stable": "npm:ospec@4.1.2-postinstall-experiments"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -924,10 +924,11 @@
     },
     "node_modules/ospec-stable": {
       "name": "ospec",
-      "version": "4.1.1-and-then-some",
-      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.1-and-then-some.tgz",
-      "integrity": "sha512-nrr+LDcGhendFzoF8YB9MLQ1/6INV60AbP8j7YihfDoF3mmVBfPqCfs9VHGH0KTDhYBICbk+NMmErg0NO+77jw==",
+      "version": "4.1.2-postinstall-experiments",
+      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.2-postinstall-experiments.tgz",
+      "integrity": "sha512-LQUCjvPIx+y6BHJ4ax303YNPsE7V2ppaijEkJqbfGdxF0Wq65BOQEWp+brtir3pR6xKj9mn4N4ejoMmDbrMfjA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -2076,9 +2077,9 @@
       "dev": true
     },
     "ospec-stable": {
-      "version": "npm:ospec@4.1.1-and-then-some",
-      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.1-and-then-some.tgz",
-      "integrity": "sha512-nrr+LDcGhendFzoF8YB9MLQ1/6INV60AbP8j7YihfDoF3mmVBfPqCfs9VHGH0KTDhYBICbk+NMmErg0NO+77jw==",
+      "version": "npm:ospec@4.1.2-postinstall-experiments",
+      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.2-postinstall-experiments.tgz",
+      "integrity": "sha512-LQUCjvPIx+y6BHJ4ax303YNPsE7V2ppaijEkJqbfGdxF0Wq65BOQEWp+brtir3pR6xKj9mn4N4ejoMmDbrMfjA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ospec",
-  "version": "4.1.2",
+  "version": "4.1.2-postinstall-experiments",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ospec",
-      "version": "4.1.2",
+      "version": "4.1.2-postinstall-experiments",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ospec",
-  "version": "4.1.2-postinstall-experiments",
+  "version": "4.1.2-postinstall-experiments-2",
   "description": "Noiseless testing framework",
   "main": "ospec.js",
   "unpkg": "ospec.js",
@@ -33,6 +33,6 @@
     "cmd-shim": "4.0.2",
     "compose-regexp": "0.6.22",
     "eslint": "^6.8.0",
-    "ospec-stable": "npm:ospec@4.1.1-and-then-some"
+    "ospec-stable": "npm:ospec@4.1.2-postinstall-experiments"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ospec",
-  "version": "4.1.2",
+  "version": "4.1.2-postinstall-experiments",
   "description": "Noiseless testing framework",
   "main": "ospec.js",
   "unpkg": "ospec.js",
@@ -10,8 +10,9 @@
   "author": "Leo Horie <leohorie@hotmail.com>",
   "license": "MIT",
   "files": [
+    "bin",
     "ospec.js",
-    "bin"
+    "scripts/rename-stable-binaries.js"
   ],
   "bin": "./bin/ospec",
   "repository": "github:MithrilJS/ospec",
@@ -19,7 +20,7 @@
     "glob": "^7.1.3"
   },
   "scripts": {
-    "postinstall": "node scripts/rename-stable-binaries.js",
+    "postinstall": "node ./scripts/rename-stable-binaries.js",
     "test": "ospec-stable tests/test-*.js",
     "test-api": "ospec-stable tests/test-api.js",
     "test-cli": "ospec-stable tests/test-cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ospec",
-  "version": "4.1.2-postinstall-experiments-2",
+  "version": "4.1.3",
   "description": "Noiseless testing framework",
   "main": "ospec.js",
   "unpkg": "ospec.js",

--- a/releasing.md
+++ b/releasing.md
@@ -16,3 +16,5 @@ Currently, the process is manual:
 9. \o/
     |
    / \
+
+10. Bump ospec-stable in `package.json` and run the test suite.

--- a/scripts/build-done-parser.js
+++ b/scripts/build-done-parser.js
@@ -1,6 +1,6 @@
 "use strict"
 
-import { sequence, either, suffix, capture } from "compose-regexp"
+const { sequence, either, suffix, capture } = require("compose-regexp")
 const zeroOrMore = suffix("*")
 const maybe = suffix("?")
 

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -2,10 +2,11 @@
 
 // TODO: properly document this
 
-import o, { report } from "ospec"
+const o = require("ospec")
+const { report } = 0
 
-import { writeFileSync, mkdirSync } from "fs"
-import { join } from "path"
+const { writeFileSync, mkdirSync } = require("node:fs")
+const { join } = require("node:path")
 
 console.log("Logging...")
 mkdirSync("./logs", {recursive: true})

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,1 +1,0 @@
-{"type": "module"}

--- a/scripts/rename-stable-binaries.js
+++ b/scripts/rename-stable-binaries.js
@@ -1,3 +1,7 @@
+// This is a dev script that is shipped with the package because
+// I couldn't find a cross-platform way of running code conditionally
+// The shell syntaxes are too complex.
+
 const {rename} = require("node:fs/promises")
 const glob = require("glob")
 

--- a/scripts/rename-stable-binaries.js
+++ b/scripts/rename-stable-binaries.js
@@ -1,14 +1,13 @@
-import {rename as fsRename} from "node:fs/promises"
-import glob from "glob"
+const {rename} = require("node:fs/promises")
+const glob = require("glob")
 
-function rename(x) {
-    fsRename(x, x.replace(/ospec(?:-stable)?((?:\.\w+)?)/, "ospec-stable$1"))
-}
+glob("node_modules/.bin/ospec*(.*)")
 
-glob("./node_modules/.bin/ospec*(.*)")
-.on("match", rename)
-.on("error", (e) => {
+.on("match", x => {rename(x, x.replace(/ospec(?:-stable)?((?:\.\w+)?)/, "ospec-stable$1"))})
+
+.on("error", e => {
     console.error(e)
     process.exit(1)
 })
+
 .on("end", () => {process.exit(0)})


### PR DESCRIPTION
Fix the post-install crash introduced in v4.1.2

## Description
<!--- Describe your changes in detail -->

For testing `ospec`, we install a previous, known stable version as a dep-dependency as "ospec-stable". the `postinstall` hook is also used to rename the corresponding files in `node_nodules/.bin` from `ospec*` to `ospec-stable*` to avoid problems in Windows (where running `ospec` from npm scripts would try to load the `ospec.js` found at the root, rather than the corresponding shell script in `node_nodules/.bin`.

`v4.1.2` tried to invoke the renaming script, but it wasn't part of the npm bundle, leading to an error when installing it as a dep. I couldn't find a way to execute JS conditionally from NPM scripts that works in both Windows and *nix, so I instead added the renaming script (~10loc) to the bundle. It is a noop when installed as a dep or dev-dep.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the change log (if applicable).
