### PR TITLE
fix: Always explicitly exit() to avoid hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ o.spec("testing", function() {
 ### Definitions
 
 - A **test** is the function passed to `o("description", function test() {})`.
-- A **hook** is a function passed to `o.before()`, `o.after()`. `o.beforeEach()` and `o.afterEach()`
+- A **hook** is a function passed to `o.before()`, `o.after()`. `o.beforeEach()` and `o.afterEach()`.
 - A **task** designates either a test or a hook.
 - A given test and its associated `beforeEach` and `afterEach` hooks form a **streak**. The `beforeEach` hooks run outermost first, the `afterEach` run outermost last. The hooks are optional, and are tied at test-definition time in the `o.spec()` calls that enclose the test.
 - A **spec** is a collection of streaks, specs, one `before` hook and one `after` hook. Each component is optional. Specs are defined with the `o.spec("spec name", function specDef() {})` calls.
@@ -698,7 +698,7 @@ While some testing libraries consider error thrown as assertions failure, `ospec
 
 - A syntax error in a file causes the file to be ignored by the runner.
 - At test-definition time:
-  - An error thrown at the root of a file will cause subsequent tests and specs to be ignored
+  - An error thrown at the root of a file will cause subsequent tests and specs to be ignored.
   - An error thrown in a spec definition will cause the spec to be ignored.
 - At test-execution time:
   - An error thrown in the `before` hook will cause the streaks and nested specs to be ignored. The `after` hook will run.

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,9 @@ Change log
 
 ### Upcoming
 
-- *Noothing yet*
+#### Bug fix
+
+- Explicitly `exit()` the process after all test have passed, to avoid the process hanging due to a dangling `setInterval` somewhere.
 
 ### 4.1.6
 _2022-05-19_

--- a/ospec.js
+++ b/ospec.js
@@ -265,7 +265,7 @@ else window.o = m()
 			if (typeof reporter === "function") reporter(results, stats)
 			else {
 				var errCount = o.report(results, stats)
-				if (hasProcess && errCount !== 0) process.exit(1) // eslint-disable-line no-process-exit
+				if (hasProcess) process.exit(errCount !== 0 ? 1 : undefined) // eslint-disable-line no-process-exit
 			}
 		}, null, null)
 


### PR DESCRIPTION
## Description

Fixes this problem:

```js
import o from 'ospec';

o.spec('This dangling setInterval', () => {
  setInterval(() => undefined, 100);

  o('causes ospec to hang', () => {
    o(true).equals(true);
  });
});
```

## Motivation and Context

Tests that import code from 3rd party libraries can cause ospec to unexpectedly hang, even though your own code and tests are perfectly fine.

## How Has This Been Tested?

By pasting the above code into a file called `hangtest.mjs` and running `ospec hangtest.mjs`.

Without the fix the process doesn't exit.

With the fix it exits like normal.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the change log (if applicable).

**BTW:** I Can't get the package tests to pass locally (MacOS 12.5) — not **even on the untouched `main` branch**:

```sh
git clone git@github.com:MithrilJS/ospec.git
cd ospec
git checkout main  # Already on 'main'
yarn install
yarn run test
# 30 out of 4024 assertions failed
yarn run self-test
# 30 out of 4024 assertions failed
```
